### PR TITLE
Fixed typo in "started".

### DIFF
--- a/source/docs/videos.md
+++ b/source/docs/videos.md
@@ -8,4 +8,4 @@ section: content
 Below are a list of videos which demonstrate using Blueprint.
 
 - [Quick Demo](https://www.youtube.com/watch?v=A_gUCwni_6c) on YouTube
-- [Getting stated and under the hood](https://laracasts.com/series/guest-spotlight/episodes/9) on Laracasts
+- [Getting started and under the hood](https://laracasts.com/series/guest-spotlight/episodes/9) on Laracasts


### PR DESCRIPTION
Just saw the typo as I was going through the docs and thought I'd fix it.