### PR TITLE
Fix typo in Defining Controllers yaml example

### DIFF
--- a/source/docs/defining-controllers.md
+++ b/source/docs/defining-controllers.md
@@ -24,7 +24,7 @@ controllers:
 
   Comment:
     show:
-      render: comment.show with:show
+      render: comment.show with:comment
 ```
 
 From this definition, Blueprint will generate two controllers. A `PostController` with `index`, `create`, and `store` actions. And a `CommentController` with a `show` action.


### PR DESCRIPTION
```yaml
  Comment:
    show:
      render: comment.show with:show
```

The example YAML above from Defining Controllers generates this

```php
return view('comment.show', compact('show'));
```

should be

```yaml
  Comment:
    show:
      render: comment.show with:comment
```

to generate this

```php
return view('comment.show', compact('comment'));
```