### PR TITLE
Removes third party package link

### DIFF
--- a/source/docs/extending-blueprint.md
+++ b/source/docs/extending-blueprint.md
@@ -26,7 +26,6 @@ You may use these addons in your projects or as an example of how to create your
 
 
 - [Laravel Nova](https://github.com/Naoray/blueprint-nova-addon): Automatically generate Nova resources for each of the models specified in your _draft file_.
-- [Pest Test Generator](https://github.com/fidum/laravel-blueprint-pestphp-addon): Generate [Pest](https://github.com/pestphp/pest) tests, instead of the standard Laravel/PHPUnit tests.
 - [API Resources Tests](https://github.com/axitbv/laravel-blueprint-streamlined-test-addon): Generate test code similar to Blueprint, but using an [opinionated and streamlined](https://github.com/laravel-shift/blueprint/pull/220) style.
 - [TALL-forms](https://github.com/tanthammar/tall-blueprint-addon): Automatically generate _TALL_ forms for each of the models specified in your draft file.
 


### PR DESCRIPTION
Now that Blueprint has first party support for PestPHP test generation 🎉  
https://github.com/laravel-shift/blueprint/releases/tag/v2.8.0

I have decided to archive my package.  So happy it made it into core eventually 🙌 